### PR TITLE
Fix post request

### DIFF
--- a/src/Mailjet/Api/Client.php
+++ b/src/Mailjet/Api/Client.php
@@ -67,7 +67,7 @@ class Client implements MailjetClientInterface
             throw new \InvalidArgumentException('Unsupported API query for POST method: ' . $apiQuery);
         }
 
-        $request = $this->getApi()->post($apiQuery);
+        $request = $this->getApi()->post($apiQuery, null, $options);
 
         $this->prepareRequest($request, $options);
 


### PR DESCRIPTION
Mailjet post request need params to be inside the post body
nor in the query string